### PR TITLE
feat: auto-detect travel and refresh prayer times on app resume

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'core/theme.dart';
 import 'providers/app_providers.dart';
 import 'screens/app_shell.dart';
 import 'screens/onboarding_screen.dart';
+import 'widgets/location_refresh_listener.dart';
 import 'services/event_log_service.dart';
 import 'services/storage_service.dart';
 
@@ -40,7 +41,7 @@ class RespectfulApp extends ConsumerWidget {
       theme: AppTheme.light(),
       darkTheme: AppTheme.dark(),
       home: settings.onboardingComplete
-          ? const AppShell()
+          ? const LocationRefreshListener(child: AppShell())
           : OnboardingScreen(
               onComplete: () {
                 ref.read(settingsProvider.notifier).completeOnboarding();

--- a/lib/providers/app_providers.dart
+++ b/lib/providers/app_providers.dart
@@ -7,6 +7,7 @@ import '../services/prayer_calculator.dart';
 import '../services/silence_scheduler.dart';
 import '../services/silence_window_calculator.dart';
 import '../services/storage_service.dart';
+import '../services/location_service.dart';
 import '../services/volume_controller.dart';
 
 // --- Singleton services ---
@@ -34,6 +35,43 @@ final silenceWindowCalculatorProvider =
 
 final silenceSchedulerProvider = Provider<SilenceScheduler>((ref) {
   return SilenceScheduler(ref.watch(volumeControllerProvider));
+});
+
+final locationServiceProvider = Provider<LocationService>((ref) {
+  return LocationService();
+});
+
+/// Refreshes location on app resume. If user has traveled >10km,
+/// updates stored coordinates so prayer times recalculate automatically.
+final locationRefreshProvider = FutureProvider<void>((ref) async {
+  final settings = ref.read(settingsProvider);
+  if (!settings.hasLocation || !settings.onboardingComplete) return;
+
+  final locationService = ref.read(locationServiceProvider);
+  final eventLog = ref.read(eventLogServiceProvider);
+
+  final position = await locationService.getCurrentPosition();
+  if (position == null) return;
+
+  final moved = locationService.hasMovedSignificantly(
+    storedLat: settings.latitude!,
+    storedLng: settings.longitude!,
+    currentLat: position.latitude,
+    currentLng: position.longitude,
+  );
+
+  if (moved) {
+    await ref.read(settingsProvider.notifier).setLocation(
+          position.latitude,
+          position.longitude,
+        );
+    await eventLog.log(
+      EventType.info,
+      'Location updated — travel detected '
+      '(${position.latitude.toStringAsFixed(2)}, '
+      '${position.longitude.toStringAsFixed(2)})',
+    );
+  }
 });
 
 // --- App Settings ---

--- a/lib/services/location_service.dart
+++ b/lib/services/location_service.dart
@@ -1,0 +1,55 @@
+import 'dart:math';
+import 'package:geolocator/geolocator.dart';
+
+/// Handles GPS location fetching and travel detection.
+class LocationService {
+  /// Fetch current GPS position. Returns null if permission denied or unavailable.
+  Future<Position?> getCurrentPosition() async {
+    final serviceEnabled = await Geolocator.isLocationServiceEnabled();
+    if (!serviceEnabled) return null;
+
+    var permission = await Geolocator.checkPermission();
+    if (permission == LocationPermission.denied) {
+      permission = await Geolocator.requestPermission();
+      if (permission == LocationPermission.denied) return null;
+    }
+    if (permission == LocationPermission.deniedForever) return null;
+
+    return Geolocator.getCurrentPosition(
+      locationSettings: const LocationSettings(accuracy: LocationAccuracy.high),
+    );
+  }
+
+  /// Check if the user has moved significantly from their stored location.
+  /// Returns true if distance exceeds [thresholdKm] (default 10km).
+  bool hasMovedSignificantly({
+    required double storedLat,
+    required double storedLng,
+    required double currentLat,
+    required double currentLng,
+    double thresholdKm = 10.0,
+  }) {
+    final distanceMeters = _haversineDistance(
+      storedLat, storedLng, currentLat, currentLng,
+    );
+    return distanceMeters > thresholdKm * 1000;
+  }
+
+  /// Haversine formula to calculate distance between two GPS points in meters.
+  double _haversineDistance(
+    double lat1, double lng1, double lat2, double lng2,
+  ) {
+    const earthRadiusMeters = 6371000.0;
+    final dLat = _toRadians(lat2 - lat1);
+    final dLng = _toRadians(lng2 - lng1);
+
+    final a = sin(dLat / 2) * sin(dLat / 2) +
+        cos(_toRadians(lat1)) * cos(_toRadians(lat2)) *
+        sin(dLng / 2) * sin(dLng / 2);
+    final c = 2 * atan2(sqrt(a), sqrt(1 - a));
+
+    return earthRadiusMeters * c;
+  }
+
+  double _toRadians(double degrees) => degrees * pi / 180;
+}

--- a/lib/widgets/location_refresh_listener.dart
+++ b/lib/widgets/location_refresh_listener.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../providers/app_providers.dart';
+
+/// Listens for app lifecycle changes and refreshes location on resume.
+/// Wrap around the app shell to auto-detect travel.
+class LocationRefreshListener extends ConsumerStatefulWidget {
+  final Widget child;
+
+  const LocationRefreshListener({super.key, required this.child});
+
+  @override
+  ConsumerState<LocationRefreshListener> createState() =>
+      _LocationRefreshListenerState();
+}
+
+class _LocationRefreshListenerState
+    extends ConsumerState<LocationRefreshListener> with WidgetsBindingObserver {
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    // Refresh on first load
+    _refreshLocation();
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      _refreshLocation();
+    }
+  }
+
+  void _refreshLocation() {
+    // Invalidate to trigger a fresh check
+    ref.invalidate(locationRefreshProvider);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Watch the provider to keep it alive
+    ref.watch(locationRefreshProvider);
+    return widget.child;
+  }
+}

--- a/test/location_service_test.dart
+++ b/test/location_service_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:respectful/services/location_service.dart';
+
+void main() {
+  late LocationService service;
+
+  setUp(() {
+    service = LocationService();
+  });
+
+  group('Travel detection', () {
+    test('detects significant movement (>10km)', () {
+      // Makkah to Jeddah (~75km)
+      expect(
+        service.hasMovedSignificantly(
+          storedLat: 21.4225,
+          storedLng: 39.8262,
+          currentLat: 21.5433,
+          currentLng: 39.1728,
+        ),
+        true,
+      );
+    });
+
+    test('ignores small movement (<10km)', () {
+      // Same neighborhood (~1km)
+      expect(
+        service.hasMovedSignificantly(
+          storedLat: 21.4225,
+          storedLng: 39.8262,
+          currentLat: 21.4280,
+          currentLng: 39.8300,
+        ),
+        false,
+      );
+    });
+
+    test('detects cross-country travel', () {
+      // Riyadh to Dubai (~900km)
+      expect(
+        service.hasMovedSignificantly(
+          storedLat: 24.7136,
+          storedLng: 46.6753,
+          currentLat: 25.2048,
+          currentLng: 55.2708,
+        ),
+        true,
+      );
+    });
+
+    test('same location returns false', () {
+      expect(
+        service.hasMovedSignificantly(
+          storedLat: 21.4225,
+          storedLng: 39.8262,
+          currentLat: 21.4225,
+          currentLng: 39.8262,
+        ),
+        false,
+      );
+    });
+
+    test('custom threshold works', () {
+      // ~5km apart, should be significant with 3km threshold
+      expect(
+        service.hasMovedSignificantly(
+          storedLat: 21.4225,
+          storedLng: 39.8262,
+          currentLat: 21.4600,
+          currentLng: 39.8500,
+          thresholdKm: 3.0,
+        ),
+        true,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Auto-detect travel and refresh prayer times. When the user opens the app after traveling >10km, GPS location updates automatically and prayer times recalculate.

## Changes
- `services/location_service.dart`: Haversine distance calculation, travel detection with configurable threshold (default 10km)
- `providers/app_providers.dart`: `locationRefreshProvider` checks GPS on app resume, updates stored coords if user traveled. `locationServiceProvider` for DI.
- `widgets/location_refresh_listener.dart`: Lifecycle-aware widget that triggers location refresh on app resume
- `main.dart`: Wraps AppShell with LocationRefreshListener

## How it works
1. Every time the app is opened/resumed, `locationRefreshProvider` fires
2. It fetches current GPS position
3. Compares against stored location using haversine formula
4. If distance >10km: updates stored lat/lng in settings
5. Settings change cascades via Riverpod: `settingsProvider` → `todayPrayerTimesProvider` → `silenceWindowsProvider` — prayer times and silence windows auto-recalculate
6. Logs the location update to the event log

## Validation
- [x] `flutter analyze` — 0 issues
- [x] `flutter test` — 22/22 passed (5 new location tests)

## Known Limitations / Follow-ups
- None — timezone changes are already handled by the native TimezoneReceiver

🤖 Generated with [Claude Code](https://claude.com/claude-code)
