### PR TITLE
feat: launch prep — privacy policy, store listing, README

### DIFF
--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -1,0 +1,60 @@
+# Privacy Policy — Respectful
+
+**Last updated:** March 2026
+
+## What Respectful Does
+
+Respectful is a prayer times app that automatically silences your phone during prayer times. It calculates prayer times locally on your device and manages your phone's Do Not Disturb settings.
+
+## Data We Collect
+
+**We do not collect, store, or transmit any personal data.**
+
+### Location Data
+- Your GPS coordinates are used **only** to calculate accurate prayer times for your area.
+- Location data is stored **locally on your device only** — it is never sent to any server.
+- Location is fetched once during setup and refreshed when you travel (>10km change detected).
+- You can manually refresh your location at any time in Settings.
+
+### Prayer Times
+- Prayer times are calculated **entirely on your device** using the open-source Adhan library.
+- No prayer time API calls are made. The app works fully offline.
+
+### Phone State
+- The app reads your phone's volume and Do Not Disturb state before silencing.
+- This state is stored **locally on your device only** to restore your phone after prayer.
+- No phone state data is ever transmitted externally.
+
+### Event Log
+- The app maintains a local activity log (last 200 events) for debugging purposes.
+- This log is stored **on your device only** and is never transmitted.
+
+## Permissions
+
+| Permission | Why It's Needed |
+|-----------|----------------|
+| Location | Calculate prayer times for your area |
+| Do Not Disturb Access | Automatically silence your phone during prayer |
+| Exact Alarms | Schedule precise silence/restore at prayer times |
+| Boot Completed | Reschedule alarms after device restart |
+
+## Third-Party Services
+
+Respectful does not use any third-party analytics, advertising, or tracking services.
+
+## Data Sharing
+
+We do not share any data with third parties. There is no data to share — everything stays on your device.
+
+## Children's Privacy
+
+Respectful does not knowingly collect information from children under 13.
+
+## Changes to This Policy
+
+We may update this privacy policy from time to time. Changes will be reflected in the "Last updated" date above.
+
+## Contact
+
+For questions about this privacy policy, please open an issue at:
+https://github.com/YIzzeldin/respectful/issues

--- a/README.md
+++ b/README.md
@@ -1,17 +1,63 @@
-# respectful
+# Respectful
 
-A new Flutter project.
+Auto-silence your phone during prayer times. Simple, beautiful, reliable.
 
-## Getting Started
+## Features
 
-This project is a starting point for a Flutter application.
+- **Auto-silence during prayer** — phone goes silent at prayer time, restores after
+- **Local prayer calculation** — works fully offline using the Adhan library, supports 12 calculation methods
+- **Per-prayer timing** — customize before/during/after silence for each prayer independently
+- **Masjid mode** — one-tap total silence when you're at the mosque, with auto-timeout
+- **Travel detection** — prayer times update automatically when you travel >10km
+- **Total or Priority silence** — choose to block everything, or allow alarms and starred contacts
+- **Activity log** — track every silence/restore event for confidence and debugging
+- **OEM troubleshooting** — device-specific guides for Samsung, Xiaomi, Huawei, OnePlus
 
-A few resources to get you started if this is your first Flutter project:
+## How It Works
 
-- [Learn Flutter](https://docs.flutter.dev/get-started/learn-flutter)
-- [Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Flutter learning resources](https://docs.flutter.dev/reference/learning-resources)
+1. **Onboarding**: Grant location + DND permission, select calculation method
+2. **Prayer times**: Calculated locally from your GPS coordinates
+3. **Silence windows**: Computed per-prayer with configurable before/during/after buffers
+4. **Exact alarms**: Android AlarmManager schedules silence/restore at precise times
+5. **Safety restore**: Redundant alarm via `setAlarmClock()` prevents phone stuck silent
+6. **Boot recovery**: Alarms reschedule automatically after device restart
 
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+## Tech Stack
+
+- **Flutter** (Android-first)
+- **Riverpod** for reactive state management
+- **Adhan** library for offline prayer time calculation
+- **Custom Kotlin platform channels** for volume/DND control
+- **AlarmManager** with BroadcastReceivers for background scheduling
+
+## Privacy
+
+Respectful collects **zero data**. Everything stays on your device. No analytics, no tracking, no API calls. See [PRIVACY_POLICY.md](PRIVACY_POLICY.md).
+
+## Building
+
+```bash
+flutter pub get
+flutter run
+```
+
+Requires Android 8.0+ (API 26).
+
+## Architecture
+
+```
+lib/
+  core/           — theme, colors
+  models/         — prayer day, timing config, silence window, suppression state
+  providers/      — Riverpod providers (settings, prayer times, auto-scheduling)
+  screens/        — home, settings, activity, onboarding, troubleshooting
+  services/       — prayer calculator, silence scheduler, volume controller, event log
+  widgets/        — prayer card, countdown banner, masjid mode button
+
+android/.../kotlin/
+  VolumeControlService.kt   — AudioManager + DND control
+  AlarmScheduler.kt         — Exact alarm scheduling
+  AlarmReceiver.kt          — Silence/restore on alarm fire
+  BootReceiver.kt           — Recovery after reboot
+  TimezoneReceiver.kt       — Recalculation on timezone change
+```

--- a/STORE_LISTING.md
+++ b/STORE_LISTING.md
@@ -1,0 +1,56 @@
+# Play Store Listing — Respectful
+
+## App Name
+Respectful — Prayer Auto-Silent
+
+## Short Description (80 chars max)
+Auto-silence your phone during prayer times. Simple, reliable, private.
+
+## Full Description
+
+Respectful automatically silences your phone during prayer times so you can focus on your salah without worrying about interruptions.
+
+**How it works:**
+Simply set your calculation method and Respectful handles the rest. Your phone silences before each prayer and restores to its previous state afterward — automatically, every day.
+
+**Key Features:**
+
+Prayer Times
+- Accurate prayer times calculated locally on your device
+- 12 calculation methods (Muslim World League, ISNA, Umm Al-Qura, Egyptian, and more)
+- Automatic updates when you travel
+
+Auto-Silence
+- Phone silences before the azan and restores after prayer
+- Customize timing for each prayer independently
+- Choose Total Silence or Priority Silence (allows alarms)
+- Works reliably in the background
+
+Masjid Mode
+- One-tap total silence when at the mosque
+- Auto-timeout prevents forgotten activation
+- Long-press to extend
+
+Smart & Reliable
+- Survives phone restarts
+- Works offline — no internet needed
+- Respects your manual overrides
+- Activity log shows every event
+- Device-specific troubleshooting guides
+
+**Privacy First:**
+Respectful collects ZERO data. No analytics, no tracking, no servers. Your location stays on your device. Prayer times are calculated locally. Everything is private.
+
+**Permissions explained:**
+- Location: to calculate prayer times for your area
+- Do Not Disturb: to silence your phone automatically
+- Exact Alarms: for precise prayer time scheduling
+
+## Category
+Lifestyle
+
+## Tags
+prayer times, salah, muslim, auto silent, do not disturb, masjid, mosque, islamic, prayer reminder, adhan
+
+## Content Rating
+Everyone

--- a/android/app/src/main/res/drawable-v21/launch_background.xml
+++ b/android/app/src/main/res/drawable-v21/launch_background.xml
@@ -1,12 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Modify this file to customize your launch splash screen -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="?android:colorBackground" />
-
-    <!-- You can insert your own image assets here -->
-    <!-- <item>
-        <bitmap
-            android:gravity="center"
-            android:src="@mipmap/launch_image" />
-    </item> -->
+    <item android:drawable="#F5F2ED" />
 </layer-list>

--- a/android/app/src/main/res/drawable/launch_background.xml
+++ b/android/app/src/main/res/drawable/launch_background.xml
@@ -1,12 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Modify this file to customize your launch splash screen -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@android:color/white" />
-
-    <!-- You can insert your own image assets here -->
-    <!-- <item>
-        <bitmap
-            android:gravity="center"
-            android:src="@mipmap/launch_image" />
-    </item> -->
+    <item android:drawable="#F5F2ED" />
 </layer-list>

--- a/lib/widgets/location_refresh_listener.dart
+++ b/lib/widgets/location_refresh_listener.dart
@@ -2,8 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/app_providers.dart';
 
-/// Listens for app lifecycle changes and refreshes location on resume.
-/// Wrap around the app shell to auto-detect travel.
+/// Listens for app lifecycle changes:
+/// - Refreshes location on resume (travel detection)
+/// - Checks for stale DND state (crash recovery)
 class LocationRefreshListener extends ConsumerStatefulWidget {
   final Widget child;
 
@@ -39,8 +40,10 @@ class _LocationRefreshListenerState
   }
 
   void _refreshLocation() {
-    // Invalidate to trigger a fresh check
     ref.invalidate(locationRefreshProvider);
+    // Also re-check permissions on resume
+    ref.invalidate(dndPermissionProvider);
+    ref.invalidate(exactAlarmPermissionProvider);
   }
 
   @override


### PR DESCRIPTION
## Summary
Launch preparation: privacy policy, Play Store listing, proper README, splash screen theming, and permission re-check on app resume.

## Changes
- `PRIVACY_POLICY.md`: Zero-data-collection policy documenting all permissions and their purpose
- `STORE_LISTING.md`: Play Store draft — app name, short/full description, category, tags
- `README.md`: Complete project overview with features, architecture diagram, build instructions
- `android/.../launch_background.xml`: Splash screen uses warm cream (#F5F2ED) matching app theme
- `widgets/location_refresh_listener.dart`: Re-checks DND + exact alarm permissions on app resume

## Validation
- [x] `flutter analyze` — 0 issues
- [x] `flutter test` — 22/22 passed

## Known Limitations / Follow-ups
- App icon needs custom design (currently using default Flutter icon)
- Screenshots needed for Play Store listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
