### PR TITLE
feat: simplify timing to before-iqamah/after-prayer + separate mode toggles

### DIFF
--- a/lib/models/app_settings.dart
+++ b/lib/models/app_settings.dart
@@ -80,7 +80,12 @@ extension SilenceLevelDisplay on SilenceLevel {
 class AppSettings {
   final CalculationMethodType calculationMethod;
   final TimingPreferences timingPreferences;
-  final bool autoSilentEnabled;
+  /// Time-based auto-silence (silence at prayer times). OFF by default.
+  final bool timeBasedSilenceEnabled;
+
+  /// Geofence-based auto-silence (silence at saved masjids). ON by default — main use case.
+  final bool geofenceSilenceEnabled;
+
   final SilenceLevel silenceLevel;
   final bool usePerPrayerConfig;
   final bool onboardingComplete;
@@ -90,7 +95,8 @@ class AppSettings {
   const AppSettings({
     this.calculationMethod = CalculationMethodType.muslimWorldLeague,
     required this.timingPreferences,
-    this.autoSilentEnabled = true,
+    this.timeBasedSilenceEnabled = false,
+    this.geofenceSilenceEnabled = true,
     this.silenceLevel = SilenceLevel.totalSilence,
     this.usePerPrayerConfig = false,
     this.onboardingComplete = false,
@@ -107,7 +113,8 @@ class AppSettings {
   AppSettings copyWith({
     CalculationMethodType? calculationMethod,
     TimingPreferences? timingPreferences,
-    bool? autoSilentEnabled,
+    bool? timeBasedSilenceEnabled,
+    bool? geofenceSilenceEnabled,
     SilenceLevel? silenceLevel,
     bool? usePerPrayerConfig,
     bool? onboardingComplete,
@@ -117,7 +124,8 @@ class AppSettings {
       AppSettings(
         calculationMethod: calculationMethod ?? this.calculationMethod,
         timingPreferences: timingPreferences ?? this.timingPreferences,
-        autoSilentEnabled: autoSilentEnabled ?? this.autoSilentEnabled,
+        timeBasedSilenceEnabled: timeBasedSilenceEnabled ?? this.timeBasedSilenceEnabled,
+        geofenceSilenceEnabled: geofenceSilenceEnabled ?? this.geofenceSilenceEnabled,
         silenceLevel: silenceLevel ?? this.silenceLevel,
         usePerPrayerConfig: usePerPrayerConfig ?? this.usePerPrayerConfig,
         onboardingComplete: onboardingComplete ?? this.onboardingComplete,

--- a/lib/models/prayer_timing_config.dart
+++ b/lib/models/prayer_timing_config.dart
@@ -2,101 +2,118 @@ import 'prayer_day.dart';
 
 /// Per-prayer timing configuration.
 ///
-/// Timeline: [minutesBefore azan] → AZAN → [iqamahOffsetMinutes] → PRAYER START → [durationMinutes] → [minutesAfter]
+/// Simplified model: user only controls two things:
+///   1. Minutes to silence BEFORE the iqamah
+///   2. Minutes to stay silent AFTER the prayer
 ///
-/// The adhan library gives us the AZAN time. The actual prayer starts
-/// iqamahOffsetMinutes later. Silence window covers the full range.
+/// Prayer duration is fixed at 10 minutes (not user-configurable).
+///
+/// Timeline: [minutesBeforeIqamah] → IQAMAH → [10 min prayer] → [minutesAfter]
+///
+/// The adhan library gives us the AZAN time. We add iqamahOffsetMinutes
+/// (the gap between azan and iqamah, per prayer) to get the iqamah time.
+/// Then the silence window starts minutesBeforeIqamah before that.
 class PrayerTimingConfig {
-  /// Minutes to silence BEFORE the azan.
-  final int minutesBefore;
+  /// Minutes to silence BEFORE the iqamah (prayer start).
+  final int minutesBeforeIqamah;
 
-  /// Minutes between azan and iqamah (when prayer actually starts).
+  /// Minutes between azan and iqamah. This is a fixed per-prayer value,
+  /// not directly user-configurable (set via defaults or advanced settings).
   final int iqamahOffsetMinutes;
-
-  /// Duration of the prayer itself in minutes.
-  final int durationMinutes;
 
   /// Minutes to stay silent AFTER the prayer ends.
   final int minutesAfter;
 
   final bool enabled;
 
+  /// Fixed prayer duration — not user-configurable.
+  static const int prayerDurationMinutes = 10;
+
   const PrayerTimingConfig({
-    required this.minutesBefore,
+    required this.minutesBeforeIqamah,
     this.iqamahOffsetMinutes = 15,
-    required this.durationMinutes,
     required this.minutesAfter,
     this.enabled = true,
   });
 
   /// Total silence window length in minutes.
   int get totalMinutes =>
-      minutesBefore + iqamahOffsetMinutes + durationMinutes + minutesAfter;
+      minutesBeforeIqamah + prayerDurationMinutes + minutesAfter;
+
+  /// The full window from azan perspective (used by silence window calculator).
+  /// Silence starts at: azan_time + iqamahOffset - minutesBeforeIqamah
+  /// Silence ends at: azan_time + iqamahOffset + prayerDuration + minutesAfter
+  int get minutesBeforeAzan {
+    final beforeIqamahFromAzan = iqamahOffsetMinutes - minutesBeforeIqamah;
+    return beforeIqamahFromAzan < 0 ? -beforeIqamahFromAzan : 0;
+  }
 
   Map<String, dynamic> toJson() => {
-        'minutesBefore': minutesBefore,
+        'minutesBeforeIqamah': minutesBeforeIqamah,
         'iqamahOffsetMinutes': iqamahOffsetMinutes,
-        'durationMinutes': durationMinutes,
         'minutesAfter': minutesAfter,
         'enabled': enabled,
       };
 
-  /// Deserialize. If iqamahOffsetMinutes is missing (pre-migration data),
-  /// the caller should provide the prayer name for correct defaults.
   factory PrayerTimingConfig.fromJson(Map<String, dynamic> json, [PrayerName? prayer]) {
-    // If iqamahOffsetMinutes is absent in stored data, use prayer-specific default
-    final hasIqamah = json.containsKey('iqamahOffsetMinutes');
-    final defaultIqamah = prayer != null
-        ? PrayerTimingConfig.defaultFor(prayer).iqamahOffsetMinutes
-        : 15;
+    final defaultConfig = prayer != null
+        ? PrayerTimingConfig.defaultFor(prayer)
+        : const PrayerTimingConfig(minutesBeforeIqamah: 10, minutesAfter: 5);
 
+    // Migration: handle old format with minutesBefore/durationMinutes
+    if (json.containsKey('minutesBeforeIqamah')) {
+      return PrayerTimingConfig(
+        minutesBeforeIqamah: json['minutesBeforeIqamah'] as int? ?? defaultConfig.minutesBeforeIqamah,
+        iqamahOffsetMinutes: json['iqamahOffsetMinutes'] as int? ?? defaultConfig.iqamahOffsetMinutes,
+        minutesAfter: json['minutesAfter'] as int? ?? defaultConfig.minutesAfter,
+        enabled: json['enabled'] as bool? ?? true,
+      );
+    }
+
+    // Old format migration: convert minutesBefore + iqamahOffset to minutesBeforeIqamah
+    final oldBefore = json['minutesBefore'] as int? ?? 5;
+    final oldIqamah = json['iqamahOffsetMinutes'] as int? ?? defaultConfig.iqamahOffsetMinutes;
     return PrayerTimingConfig(
-      minutesBefore: json['minutesBefore'] as int? ?? 5,
-      iqamahOffsetMinutes: hasIqamah
-          ? json['iqamahOffsetMinutes'] as int
-          : defaultIqamah,
-      durationMinutes: json['durationMinutes'] as int? ?? 20,
+      minutesBeforeIqamah: oldBefore + oldIqamah, // combine into single "before iqamah"
+      iqamahOffsetMinutes: oldIqamah,
       minutesAfter: json['minutesAfter'] as int? ?? 5,
       enabled: json['enabled'] as bool? ?? true,
     );
   }
 
   /// Sensible defaults per prayer.
-  /// iqamahOffset varies: Maghrib is short (5 min), Jumu'ah is long (30 min for khutbah).
   static PrayerTimingConfig defaultFor(PrayerName prayer) {
     switch (prayer) {
       case PrayerName.fajr:
         return const PrayerTimingConfig(
-            minutesBefore: 5, iqamahOffsetMinutes: 20, durationMinutes: 15, minutesAfter: 5);
+            minutesBeforeIqamah: 25, iqamahOffsetMinutes: 20, minutesAfter: 5);
       case PrayerName.dhuhr:
         return const PrayerTimingConfig(
-            minutesBefore: 5, iqamahOffsetMinutes: 15, durationMinutes: 15, minutesAfter: 5);
+            minutesBeforeIqamah: 20, iqamahOffsetMinutes: 15, minutesAfter: 5);
       case PrayerName.asr:
         return const PrayerTimingConfig(
-            minutesBefore: 5, iqamahOffsetMinutes: 15, durationMinutes: 15, minutesAfter: 5);
+            minutesBeforeIqamah: 20, iqamahOffsetMinutes: 15, minutesAfter: 5);
       case PrayerName.maghrib:
         return const PrayerTimingConfig(
-            minutesBefore: 5, iqamahOffsetMinutes: 5, durationMinutes: 10, minutesAfter: 5);
+            minutesBeforeIqamah: 10, iqamahOffsetMinutes: 5, minutesAfter: 5);
       case PrayerName.isha:
         return const PrayerTimingConfig(
-            minutesBefore: 5, iqamahOffsetMinutes: 15, durationMinutes: 15, minutesAfter: 5);
+            minutesBeforeIqamah: 20, iqamahOffsetMinutes: 15, minutesAfter: 5);
       case PrayerName.jumuah:
         return const PrayerTimingConfig(
-            minutesBefore: 10, iqamahOffsetMinutes: 30, durationMinutes: 20, minutesAfter: 10);
+            minutesBeforeIqamah: 40, iqamahOffsetMinutes: 30, minutesAfter: 10);
     }
   }
 
   PrayerTimingConfig copyWith({
-    int? minutesBefore,
+    int? minutesBeforeIqamah,
     int? iqamahOffsetMinutes,
-    int? durationMinutes,
     int? minutesAfter,
     bool? enabled,
   }) =>
       PrayerTimingConfig(
-        minutesBefore: minutesBefore ?? this.minutesBefore,
+        minutesBeforeIqamah: minutesBeforeIqamah ?? this.minutesBeforeIqamah,
         iqamahOffsetMinutes: iqamahOffsetMinutes ?? this.iqamahOffsetMinutes,
-        durationMinutes: durationMinutes ?? this.durationMinutes,
         minutesAfter: minutesAfter ?? this.minutesAfter,
         enabled: enabled ?? this.enabled,
       );

--- a/lib/providers/app_providers.dart
+++ b/lib/providers/app_providers.dart
@@ -129,8 +129,12 @@ class SettingsNotifier extends StateNotifier<AppSettings> {
     await updateSettings(state.copyWith(calculationMethod: method));
   }
 
-  Future<void> setAutoSilentEnabled(bool enabled) async {
-    await updateSettings(state.copyWith(autoSilentEnabled: enabled));
+  Future<void> setTimeBasedSilenceEnabled(bool enabled) async {
+    await updateSettings(state.copyWith(timeBasedSilenceEnabled: enabled));
+  }
+
+  Future<void> setGeofenceSilenceEnabled(bool enabled) async {
+    await updateSettings(state.copyWith(geofenceSilenceEnabled: enabled));
   }
 
   Future<void> setSilenceLevel(SilenceLevel level) async {
@@ -243,7 +247,7 @@ final autoScheduleProvider = FutureProvider<void>((ref) async {
   final windows = ref.watch(silenceWindowsProvider);
   final settings = ref.watch(settingsProvider);
 
-  if (!settings.autoSilentEnabled || windows.isEmpty) {
+  if (!settings.timeBasedSilenceEnabled || windows.isEmpty) {
     // Cancel any existing alarms when disabled
     if (_lastScheduledHash != 0) {
       final scheduler = ref.read(silenceSchedulerProvider);
@@ -281,9 +285,10 @@ final autoScheduleProvider = FutureProvider<void>((ref) async {
 
 final autoGeofenceProvider = FutureProvider<void>((ref) async {
   final masjids = ref.watch(savedMasjidsProvider);
+  final settings = ref.watch(settingsProvider);
   final controller = ref.read(volumeControllerProvider);
 
-  if (masjids.isEmpty) {
+  if (masjids.isEmpty || !settings.geofenceSilenceEnabled) {
     await controller.removeAllGeofences();
     return;
   }
@@ -433,7 +438,7 @@ class MasjidModeNotifier extends StateNotifier<MasjidModeState> {
     // Reschedule prayer alarms (masjid deactivation doesn't change silence windows,
     // so autoScheduleProvider won't re-run. We must manually reschedule.)
     final settings = _getSettings();
-    if (settings.autoSilentEnabled) {
+    if (settings.timeBasedSilenceEnabled) {
       final windows = _getWindows();
       if (windows.isNotEmpty) {
         await _scheduler.scheduleAll(windows);

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -23,7 +23,7 @@ class HomeScreen extends ConsumerWidget {
       body: SafeArea(
         child: prayerDay == null
             ? _buildNoLocation(context)
-            : _buildContent(context, ref, prayerDay, nextPrayer, activeWindow != null, settings.autoSilentEnabled),
+            : _buildContent(context, ref, prayerDay, nextPrayer, activeWindow != null, settings.timeBasedSilenceEnabled),
       ),
     );
   }
@@ -59,7 +59,7 @@ class HomeScreen extends ConsumerWidget {
     PrayerDay day,
     (PrayerName, DateTime)? nextPrayer,
     bool isSilenced,
-    bool autoSilentEnabled,
+    bool timeBasedSilenceEnabled,
   ) {
     final now = DateTime.now();
     final greeting = _getGreeting(now);
@@ -94,12 +94,12 @@ class HomeScreen extends ConsumerWidget {
             ),
             GestureDetector(
               onTap: () {
-                ref.read(settingsProvider.notifier).setAutoSilentEnabled(!autoSilentEnabled);
+                ref.read(settingsProvider.notifier).setTimeBasedSilenceEnabled(!timeBasedSilenceEnabled);
               },
               child: Container(
                 padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
                 decoration: BoxDecoration(
-                  color: autoSilentEnabled
+                  color: timeBasedSilenceEnabled
                       ? AppColors.primary.withValues(alpha: 0.1)
                       : AppColors.error.withValues(alpha: 0.1),
                   borderRadius: BorderRadius.circular(20),
@@ -108,17 +108,17 @@ class HomeScreen extends ConsumerWidget {
                   mainAxisSize: MainAxisSize.min,
                   children: [
                     Icon(
-                      autoSilentEnabled ? Icons.volume_off : Icons.volume_up,
+                      timeBasedSilenceEnabled ? Icons.volume_off : Icons.volume_up,
                       size: 14,
-                      color: autoSilentEnabled ? AppColors.primary : AppColors.error,
+                      color: timeBasedSilenceEnabled ? AppColors.primary : AppColors.error,
                     ),
                     const SizedBox(width: 4),
                     Text(
-                      autoSilentEnabled ? 'ON' : 'OFF',
+                      timeBasedSilenceEnabled ? 'ON' : 'OFF',
                       style: TextStyle(
                         fontSize: 11,
                         fontWeight: FontWeight.w700,
-                        color: autoSilentEnabled ? AppColors.primary : AppColors.error,
+                        color: timeBasedSilenceEnabled ? AppColors.primary : AppColors.error,
                       ),
                     ),
                   ],

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -23,14 +23,33 @@ class SettingsScreen extends ConsumerWidget {
           padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
           children: [
             // Header
-            Row(
+            Text('Settings', style: Theme.of(context).textTheme.headlineMedium),
+            const SizedBox(height: 24),
+
+            // Silence Modes — geofence ON by default, time-based OFF by default
+            _SectionCard(
+              title: 'Silence Modes',
               children: [
-                const Icon(Icons.arrow_back, color: AppColors.textPrimary),
-                const SizedBox(width: 12),
-                Text('Settings', style: Theme.of(context).textTheme.headlineMedium),
+                _ToggleRow(
+                  icon: Icons.mosque_rounded,
+                  label: 'Masjid Detection',
+                  subtitle: 'Auto-silence when near a saved masjid',
+                  value: settings.geofenceSilenceEnabled,
+                  onChanged: (v) => ref.read(settingsProvider.notifier)
+                      .setGeofenceSilenceEnabled(v),
+                ),
+                const Divider(height: 20),
+                _ToggleRow(
+                  icon: Icons.schedule_rounded,
+                  label: 'Time-Based Silence',
+                  subtitle: 'Auto-silence at prayer times',
+                  value: settings.timeBasedSilenceEnabled,
+                  onChanged: (v) => ref.read(settingsProvider.notifier)
+                      .setTimeBasedSilenceEnabled(v),
+                ),
               ],
             ),
-            const SizedBox(height: 24),
+            const SizedBox(height: 16),
 
             // Silence Level
             _SectionCard(
@@ -56,25 +75,25 @@ class SettingsScreen extends ConsumerWidget {
             ),
             const SizedBox(height: 16),
 
+            // Timing sections — only visible when time-based silence is ON
+            if (settings.timeBasedSilenceEnabled) ...[
             // Default Timing — show range across all prayers
             Builder(builder: (context) {
               final configs = [PrayerName.fajr, PrayerName.dhuhr, PrayerName.asr,
                   PrayerName.maghrib, PrayerName.isha]
                   .map((p) => settings.timingPreferences.configFor(p))
                   .toList();
-              final beforeMin = configs.map((c) => c.minutesBefore).reduce((a, b) => a < b ? a : b);
-              final beforeMax = configs.map((c) => c.minutesBefore).reduce((a, b) => a > b ? a : b);
-              final durMin = configs.map((c) => c.durationMinutes).reduce((a, b) => a < b ? a : b);
-              final durMax = configs.map((c) => c.durationMinutes).reduce((a, b) => a > b ? a : b);
+              final beforeMin = configs.map((c) => c.minutesBeforeIqamah).reduce((a, b) => a < b ? a : b);
+              final beforeMax = configs.map((c) => c.minutesBeforeIqamah).reduce((a, b) => a > b ? a : b);
               final afterMin = configs.map((c) => c.minutesAfter).reduce((a, b) => a < b ? a : b);
               final afterMax = configs.map((c) => c.minutesAfter).reduce((a, b) => a > b ? a : b);
 
               return _SectionCard(
                 title: 'Default Timing',
                 children: [
-                  _TimingRow(label: 'Before prayer', value: beforeMin, unit: beforeMin == beforeMax ? 'min' : '-$beforeMax min'),
+                  _TimingRow(label: 'Before iqamah', value: beforeMin, unit: beforeMin == beforeMax ? 'min' : '-$beforeMax min'),
                   const Divider(height: 24),
-                  _TimingRow(label: 'Prayer duration', value: durMin, unit: durMin == durMax ? 'min' : '-$durMax min'),
+                  _TimingRow(label: 'Prayer duration', value: PrayerTimingConfig.prayerDurationMinutes, unit: 'min (fixed)'),
                   const Divider(height: 24),
                   _TimingRow(label: 'After prayer', value: afterMin, unit: afterMin == afterMax ? 'min' : '-$afterMax min'),
                 ],
@@ -102,6 +121,7 @@ class SettingsScreen extends ConsumerWidget {
               ],
             ),
             const SizedBox(height: 16),
+            ], // end of timeBasedSilenceEnabled block
 
             // Calculation Method
             _SectionCard(
@@ -295,6 +315,46 @@ class _SilenceLevelOption extends StatelessWidget {
   }
 }
 
+class _ToggleRow extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final String subtitle;
+  final bool value;
+  final ValueChanged<bool> onChanged;
+
+  const _ToggleRow({
+    required this.icon,
+    required this.label,
+    required this.subtitle,
+    required this.value,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Icon(icon, size: 20, color: value ? AppColors.primary : AppColors.textTertiary),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(label, style: const TextStyle(fontSize: 15, fontWeight: FontWeight.w500)),
+              Text(subtitle, style: const TextStyle(fontSize: 12, color: AppColors.textTertiary)),
+            ],
+          ),
+        ),
+        Switch(
+          value: value,
+          activeTrackColor: AppColors.primary,
+          onChanged: onChanged,
+        ),
+      ],
+    );
+  }
+}
+
 class _TimingRow extends StatelessWidget {
   final String label;
   final int value;
@@ -359,8 +419,9 @@ class _PerPrayerTimingCard extends StatelessWidget {
                     ),
                     const SizedBox(height: 2),
                     Text(
-                      '${config.minutesBefore}m before · ${config.iqamahOffsetMinutes}m iqamah · '
-                      '${config.durationMinutes}m prayer · ${config.minutesAfter}m after',
+                      '${config.minutesBeforeIqamah}m before iqamah · '
+                      '${PrayerTimingConfig.prayerDurationMinutes}m prayer · '
+                      '${config.minutesAfter}m after',
                       style: const TextStyle(fontSize: 11, color: AppColors.textTertiary),
                     ),
                   ],
@@ -428,23 +489,19 @@ class _TimingEditorSheet extends StatefulWidget {
 }
 
 class _TimingEditorSheetState extends State<_TimingEditorSheet> {
-  late int _minutesBefore;
-  late int _iqamahOffset;
-  late int _duration;
+  late int _beforeIqamah;
   late int _minutesAfter;
   late bool _enabled;
 
   @override
   void initState() {
     super.initState();
-    _minutesBefore = widget.initialConfig.minutesBefore;
-    _iqamahOffset = widget.initialConfig.iqamahOffsetMinutes;
-    _duration = widget.initialConfig.durationMinutes;
+    _beforeIqamah = widget.initialConfig.minutesBeforeIqamah;
     _minutesAfter = widget.initialConfig.minutesAfter;
     _enabled = widget.initialConfig.enabled;
   }
 
-  int get _total => _minutesBefore + _iqamahOffset + _duration + _minutesAfter;
+  int get _total => _beforeIqamah + PrayerTimingConfig.prayerDurationMinutes + _minutesAfter;
 
   @override
   Widget build(BuildContext context) {
@@ -478,9 +535,9 @@ class _TimingEditorSheetState extends State<_TimingEditorSheet> {
             ],
           ),
           const SizedBox(height: 8),
-          const Text(
-            'Timeline: Before Azan → Azan → Iqamah → Prayer → After',
-            style: TextStyle(fontSize: 12, color: AppColors.textTertiary),
+          Text(
+            'Prayer duration: ${PrayerTimingConfig.prayerDurationMinutes} min (fixed)',
+            style: const TextStyle(fontSize: 12, color: AppColors.textTertiary),
           ),
           const SizedBox(height: 24),
 
@@ -498,27 +555,13 @@ class _TimingEditorSheetState extends State<_TimingEditorSheet> {
           ),
           const SizedBox(height: 16),
 
-          // Sliders
+          // Sliders — just 2 settings
           _SliderRow(
-            label: 'Before azan',
-            value: _minutesBefore,
+            label: 'Before iqamah',
+            value: _beforeIqamah,
             min: 0,
-            max: 30,
-            onChanged: (v) => setState(() => _minutesBefore = v),
-          ),
-          _SliderRow(
-            label: 'Azan to iqamah',
-            value: _iqamahOffset,
-            min: 0,
-            max: 45,
-            onChanged: (v) => setState(() => _iqamahOffset = v),
-          ),
-          _SliderRow(
-            label: 'Prayer duration',
-            value: _duration,
-            min: 5,
             max: 60,
-            onChanged: (v) => setState(() => _duration = v),
+            onChanged: (v) => setState(() => _beforeIqamah = v),
           ),
           _SliderRow(
             label: 'After prayer',
@@ -536,9 +579,8 @@ class _TimingEditorSheetState extends State<_TimingEditorSheet> {
             child: ElevatedButton(
               onPressed: () {
                 widget.onSave(PrayerTimingConfig(
-                  minutesBefore: _minutesBefore,
-                  iqamahOffsetMinutes: _iqamahOffset,
-                  durationMinutes: _duration,
+                  minutesBeforeIqamah: _beforeIqamah,
+                  iqamahOffsetMinutes: widget.initialConfig.iqamahOffsetMinutes,
                   minutesAfter: _minutesAfter,
                   enabled: _enabled,
                 ));
@@ -553,9 +595,7 @@ class _TimingEditorSheetState extends State<_TimingEditorSheet> {
               onPressed: () {
                 final defaultConfig = PrayerTimingConfig.defaultFor(widget.prayer);
                 setState(() {
-                  _minutesBefore = defaultConfig.minutesBefore;
-                  _iqamahOffset = defaultConfig.iqamahOffsetMinutes;
-                  _duration = defaultConfig.durationMinutes;
+                  _beforeIqamah = defaultConfig.minutesBeforeIqamah;
                   _minutesAfter = defaultConfig.minutesAfter;
                   _enabled = defaultConfig.enabled;
                 });

--- a/lib/services/silence_window_calculator.dart
+++ b/lib/services/silence_window_calculator.dart
@@ -34,13 +34,14 @@ class SilenceWindowCalculator {
               ? PrayerName.jumuah
               : prayer;
 
-      // Timeline: [minutesBefore] → AZAN → [iqamahOffset] → PRAYER → [duration] → [minutesAfter]
       // prayerTime from adhan = azan time
-      final start =
-          prayerTime.subtract(Duration(minutes: config.minutesBefore));
-      final end = prayerTime.add(Duration(
-          minutes: config.iqamahOffsetMinutes +
-              config.durationMinutes +
+      // iqamah time = azan + iqamahOffsetMinutes
+      // Silence starts: iqamah - minutesBeforeIqamah = azan + iqamahOffset - beforeIqamah
+      // Silence ends: iqamah + prayerDuration + minutesAfter
+      final iqamahTime = prayerTime.add(Duration(minutes: config.iqamahOffsetMinutes));
+      final start = iqamahTime.subtract(Duration(minutes: config.minutesBeforeIqamah));
+      final end = iqamahTime.add(Duration(
+          minutes: PrayerTimingConfig.prayerDurationMinutes +
               config.minutesAfter));
 
       windows.add(SilenceWindow(
@@ -67,12 +68,12 @@ class SilenceWindowCalculator {
     if (fajrConfig.enabled) {
       final fajrTime = tomorrow.timeForPrayer(PrayerName.fajr);
       if (fajrTime != null) {
+        final fajrIqamah = fajrTime.add(Duration(minutes: fajrConfig.iqamahOffsetMinutes));
         final fajrWindow = SilenceWindow(
           prayer: PrayerName.fajr,
-          start: fajrTime.subtract(Duration(minutes: fajrConfig.minutesBefore)),
-          end: fajrTime.add(Duration(
-              minutes: fajrConfig.iqamahOffsetMinutes +
-                  fajrConfig.durationMinutes +
+          start: fajrIqamah.subtract(Duration(minutes: fajrConfig.minutesBeforeIqamah)),
+          end: fajrIqamah.add(Duration(
+              minutes: PrayerTimingConfig.prayerDurationMinutes +
                   fajrConfig.minutesAfter)),
         );
         // Only add if it doesn't overlap with today's windows

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -8,6 +8,7 @@ class StorageService {
   static const _keyCalculationMethod = 'calculation_method';
   static const _keyTimingPreferences = 'timing_preferences';
   static const _keyAutoSilentEnabled = 'auto_silent_enabled';
+  static const _keyGeofenceSilenceEnabled = 'geofence_silence_enabled';
   static const _keySilenceLevel = 'silence_level';
   static const _keyUsePerPrayerConfig = 'use_per_prayer_config';
   static const _keyOnboardingComplete = 'onboarding_complete';
@@ -37,7 +38,8 @@ class StorageService {
           ? TimingPreferences.fromJson(
               jsonDecode(timingJson) as Map<String, dynamic>)
           : TimingPreferences.defaults(),
-      autoSilentEnabled: _prefs.getBool(_keyAutoSilentEnabled) ?? true,
+      timeBasedSilenceEnabled: _prefs.getBool(_keyAutoSilentEnabled) ?? false,
+      geofenceSilenceEnabled: _prefs.getBool(_keyGeofenceSilenceEnabled) ?? true,
       silenceLevel: _enumByName(
         SilenceLevel.values,
         silenceLevelName,
@@ -56,7 +58,8 @@ class StorageService {
         _keyCalculationMethod, settings.calculationMethod.name);
     await _prefs.setString(
         _keyTimingPreferences, jsonEncode(settings.timingPreferences.toJson()));
-    await _prefs.setBool(_keyAutoSilentEnabled, settings.autoSilentEnabled);
+    await _prefs.setBool(_keyAutoSilentEnabled, settings.timeBasedSilenceEnabled);
+    await _prefs.setBool(_keyGeofenceSilenceEnabled, settings.geofenceSilenceEnabled);
     await _prefs.setString(_keySilenceLevel, settings.silenceLevel.name);
     await _prefs.setBool(_keyUsePerPrayerConfig, settings.usePerPrayerConfig);
     await _prefs.setBool(_keyOnboardingComplete, settings.onboardingComplete);

--- a/test/silence_window_calculator_test.dart
+++ b/test/silence_window_calculator_test.dart
@@ -39,20 +39,20 @@ void main() {
       expect(windows.length, 5);
     });
 
-    test('window start is prayer_time - minutesBefore', () {
+    test('window start is iqamah_time - minutesBeforeIqamah', () {
       final day = makePrayerDay();
       final windows = calculator.computeWindows(day, defaultPrefs);
       final fajrWindow = windows.first;
-      // Default Fajr: 5 min before
+      // Fajr: azan 5:15, iqamah 5:35 (offset 20), beforeIqamah 25 → start 5:10
       expect(fajrWindow.start, DateTime(2026, 3, 18, 5, 10));
     });
 
-    test('window end includes iqamah + duration + minutesAfter', () {
+    test('window end is iqamah + prayerDuration + minutesAfter', () {
       final day = makePrayerDay();
       final windows = calculator.computeWindows(day, defaultPrefs);
       final fajrWindow = windows.first;
-      // Default Fajr: azan 5:15 + 20m iqamah + 15m duration + 5m after = 5:55
-      expect(fajrWindow.end, DateTime(2026, 3, 18, 5, 55));
+      // Fajr: iqamah 5:35 + 10m prayer + 5m after = 5:50
+      expect(fajrWindow.end, DateTime(2026, 3, 18, 5, 50));
     });
 
     test('disabled prayer is skipped', () {
@@ -76,9 +76,10 @@ void main() {
       final dhuhrWindow = windows.firstWhere(
         (w) => w.prayer == PrayerName.jumuah,
       );
-      // Jumu'ah default: 10 before, azan 12:30, +30 iqamah, +20 duration, +10 after = 13:30
+      // Jumu'ah: azan 12:30, iqamah 13:00 (offset 30), beforeIqamah 40 → start 12:20
+      // end = 13:00 + 10 prayer + 10 after = 13:20
       expect(dhuhrWindow.start, DateTime(2026, 3, 20, 12, 20));
-      expect(dhuhrWindow.end, DateTime(2026, 3, 20, 13, 30));
+      expect(dhuhrWindow.end, DateTime(2026, 3, 20, 13, 20));
     });
 
     test('uses Dhuhr config on non-Friday', () {
@@ -89,31 +90,30 @@ void main() {
       final dhuhrWindow = windows.firstWhere(
         (w) => w.prayer == PrayerName.dhuhr,
       );
-      // Dhuhr default: 5 before, azan 12:30, +15 iqamah, +15 duration, +5 after = 13:05
+      // Dhuhr: azan 12:30, iqamah 12:45 (offset 15), beforeIqamah 20 → start 12:25
+      // end = 12:45 + 10 prayer + 5 after = 13:00
       expect(dhuhrWindow.start, DateTime(2026, 3, 19, 12, 25));
-      expect(dhuhrWindow.end, DateTime(2026, 3, 19, 13, 5));
+      expect(dhuhrWindow.end, DateTime(2026, 3, 19, 13, 0));
     });
   });
 
   group('Overlapping window merging', () {
     test('merges overlapping Maghrib and Isha', () {
-      // Use iqamahOffset=0 to simplify the math for this test
+      // Use iqamahOffset=0 and large beforeIqamah to force overlap
       final prefs = defaultPrefs
           .withConfig(
             PrayerName.maghrib,
             const PrayerTimingConfig(
-              minutesBefore: 5,
+              minutesBeforeIqamah: 5,
               iqamahOffsetMinutes: 0,
-              durationMinutes: 60,
-              minutesAfter: 15,
+              minutesAfter: 60, // long after — will overlap with Isha
             ),
           )
           .withConfig(
             PrayerName.isha,
             const PrayerTimingConfig(
-              minutesBefore: 10,
+              minutesBeforeIqamah: 10,
               iqamahOffsetMinutes: 0,
-              durationMinutes: 25,
               minutesAfter: 5,
             ),
           );
@@ -124,9 +124,9 @@ void main() {
       );
       final closeWindows = calculator.computeWindows(closeDay, prefs);
 
-      // Maghrib: 18:15 - 19:35 (5 before, 0 iqamah, 60 dur, 15 after)
-      // Isha: 19:10 - 19:50 (10 before 19:20, 0 iqamah, 25 dur, 5 after)
-      // Overlap → merged
+      // Maghrib: start=18:15 (18:20-5), end=18:20+10+60=19:30
+      // Isha: start=19:10 (19:20-10), end=19:20+10+5=19:35
+      // Overlap → merged 18:15-19:35
       final mergedWindow = closeWindows.firstWhere(
         (w) => w.mergedPrayers.isNotEmpty,
         orElse: () => closeWindows.last,
@@ -135,20 +135,28 @@ void main() {
       expect(mergedWindow.mergedPrayers.contains(PrayerName.maghrib), true);
       expect(mergedWindow.mergedPrayers.contains(PrayerName.isha), true);
       expect(mergedWindow.start, DateTime(2026, 3, 18, 18, 15));
-      expect(mergedWindow.end, DateTime(2026, 3, 18, 19, 50));
+      expect(mergedWindow.end, DateTime(2026, 3, 18, 19, 35));
     });
 
     test('adjacent windows (end == start) are merged', () {
-      // Set Dhuhr to end exactly when Asr starts
+      // Set Dhuhr with large minutesAfter so its window extends to Asr start
       final prefs = defaultPrefs.withConfig(
         PrayerName.dhuhr,
         const PrayerTimingConfig(
-          minutesBefore: 5,
-          durationMinutes: 190, // ends at 15:40
-          minutesAfter: 0,
+          minutesBeforeIqamah: 5,
+          iqamahOffsetMinutes: 0,
+          minutesAfter: 185, // azan 12:30, iqamah 12:30, +10 prayer +185 after = 15:45
+        ),
+      ).withConfig(
+        PrayerName.asr,
+        const PrayerTimingConfig(
+          minutesBeforeIqamah: 5,
+          iqamahOffsetMinutes: 0,
+          minutesAfter: 5,
         ),
       );
-      // Asr at 15:45, 5 min before = starts at 15:40
+      // Asr at 15:45, iqamah=15:45, beforeIqamah 5 → starts at 15:40
+      // Dhuhr end = 12:30 + 10 + 185 = 15:45 = Asr start+5 → overlap
       final day = makePrayerDay();
       final windows = calculator.computeWindows(day, prefs);
 
@@ -187,32 +195,33 @@ void main() {
 
   group('Per-prayer customization', () {
     test('each prayer uses its own config', () {
-      // Use iqamahOffset=0 to simplify assertions
+      // Use iqamahOffset=0 so iqamah = azan time, simplifying assertions
       final prefs = TimingPreferences(configs: {
         PrayerName.fajr: const PrayerTimingConfig(
-            minutesBefore: 10, iqamahOffsetMinutes: 0, durationMinutes: 30, minutesAfter: 10),
+            minutesBeforeIqamah: 10, iqamahOffsetMinutes: 0, minutesAfter: 10),
         PrayerName.dhuhr: const PrayerTimingConfig(
-            minutesBefore: 3, iqamahOffsetMinutes: 0, durationMinutes: 15, minutesAfter: 3),
+            minutesBeforeIqamah: 3, iqamahOffsetMinutes: 0, minutesAfter: 3),
         PrayerName.asr: const PrayerTimingConfig(
-            minutesBefore: 5, iqamahOffsetMinutes: 0, durationMinutes: 20, minutesAfter: 5),
+            minutesBeforeIqamah: 5, iqamahOffsetMinutes: 0, minutesAfter: 5),
         PrayerName.maghrib: const PrayerTimingConfig(
-            minutesBefore: 2, iqamahOffsetMinutes: 0, durationMinutes: 10, minutesAfter: 2),
+            minutesBeforeIqamah: 2, iqamahOffsetMinutes: 0, minutesAfter: 2),
         PrayerName.isha: const PrayerTimingConfig(
-            minutesBefore: 5, iqamahOffsetMinutes: 0, durationMinutes: 25, minutesAfter: 5),
+            minutesBeforeIqamah: 5, iqamahOffsetMinutes: 0, minutesAfter: 5),
         PrayerName.jumuah: const PrayerTimingConfig(
-            minutesBefore: 15, iqamahOffsetMinutes: 0, durationMinutes: 60, minutesAfter: 10),
+            minutesBeforeIqamah: 15, iqamahOffsetMinutes: 0, minutesAfter: 10),
       });
 
       final day = makePrayerDay();
       final windows = calculator.computeWindows(day, prefs);
 
-      // Fajr: 5:15 - 10 before = 5:05, + 0 iqamah + 30 dur + 10 after = 5:55
+      // Fajr: azan 5:15, iqamah=azan (offset 0), before 10 → start 5:05
+      // end = 5:15 + 10 prayer + 10 after = 5:35
       expect(windows[0].start, DateTime(2026, 3, 18, 5, 5));
-      expect(windows[0].end, DateTime(2026, 3, 18, 5, 55));
+      expect(windows[0].end, DateTime(2026, 3, 18, 5, 35));
 
-      // Dhuhr: 12:30 - 3 before = 12:27, + 0 iqamah + 15 dur + 3 after = 12:48
+      // Dhuhr: azan 12:30, before 3 → start 12:27, end = 12:30 + 10 + 3 = 12:43
       expect(windows[1].start, DateTime(2026, 3, 18, 12, 27));
-      expect(windows[1].end, DateTime(2026, 3, 18, 12, 48));
+      expect(windows[1].end, DateTime(2026, 3, 18, 12, 43));
     });
   });
 


### PR DESCRIPTION
## Summary
Simplifies timing model to 2 user settings (before iqamah + after prayer) with fixed 10min prayer duration. Adds separate toggles for geofencing (ON default) vs time-based silence (OFF default). Hides timing settings when time-based is disabled. Fixes non-functional back arrow.

## Changes
- `models/prayer_timing_config.dart`: Replaced 4 fields with 2 user controls (minutesBeforeIqamah, minutesAfter). Prayer duration fixed at 10min. Old format auto-migrated.
- `models/app_settings.dart`: Replaced `autoSilentEnabled` with `timeBasedSilenceEnabled` (default OFF) + `geofenceSilenceEnabled` (default ON)
- `services/silence_window_calculator.dart`: Window calculation uses iqamah time as reference point
- `screens/settings_screen.dart`: Silence Modes section with toggle rows. Timing sections hidden when time-based OFF. Removed broken back arrow. Editor simplified to 2 sliders.
- `providers/app_providers.dart`: Updated to use new field names, geofence provider checks geofenceSilenceEnabled
- Tests updated for new timing model

## Validation
- [x] flutter analyze — 0 issues, flutter test — 22/22 (verified before commit)

## Known Limitations / Follow-ups
- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
