### PR TITLE
feat: auto-name masjids from GPS + active masjid banner

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -129,6 +129,69 @@ class HomeScreen extends ConsumerWidget {
         ),
         const SizedBox(height: 20),
 
+        // Masjid detection banner — shows when masjid mode is active
+        Builder(builder: (context) {
+          final masjidMode = ref.watch(masjidModeProvider);
+          if (!masjidMode.isActive) return const SizedBox.shrink();
+
+          return Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(14),
+            margin: const EdgeInsets.only(bottom: 16),
+            decoration: BoxDecoration(
+              color: AppColors.primaryDark,
+              borderRadius: BorderRadius.circular(14),
+            ),
+            child: Row(
+              children: [
+                Container(
+                  width: 36,
+                  height: 36,
+                  decoration: BoxDecoration(
+                    color: Colors.white.withValues(alpha: 0.15),
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: const Icon(Icons.mosque_rounded, color: Colors.white, size: 20),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Text(
+                        'Masjid Mode Active',
+                        style: TextStyle(
+                          fontSize: 14,
+                          fontWeight: FontWeight.w600,
+                          color: Colors.white,
+                        ),
+                      ),
+                      Text(
+                        'Phone silenced${masjidMode.remainingTime != null ? ' — ${masjidMode.remainingTime!.inMinutes}m remaining' : ''}',
+                        style: const TextStyle(
+                          fontSize: 12,
+                          color: Colors.white70,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                GestureDetector(
+                  onTap: () => ref.read(masjidModeProvider.notifier).deactivate(),
+                  child: Container(
+                    padding: const EdgeInsets.all(6),
+                    decoration: BoxDecoration(
+                      color: Colors.white.withValues(alpha: 0.15),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: const Icon(Icons.close, color: Colors.white, size: 16),
+                  ),
+                ),
+              ],
+            ),
+          );
+        }),
+
         // Next prayer banner
         if (nextPrayer != null)
           NextPrayerBanner(

--- a/lib/screens/masjid_screen.dart
+++ b/lib/screens/masjid_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:geocoding/geocoding.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:permission_handler/permission_handler.dart' as ph;
 import '../core/theme.dart';
@@ -249,8 +250,33 @@ class MasjidScreen extends ConsumerWidget {
 
       if (!context.mounted) return;
 
-      // Ask for name
-      final name = await _askMasjidName(context);
+      // Auto-detect address for pre-filling the name
+      String suggestedName = 'Masjid ${ref.read(savedMasjidsProvider).length + 1}';
+      try {
+        final placemarks = await placemarkFromCoordinates(
+          position.latitude,
+          position.longitude,
+        );
+        if (placemarks.isNotEmpty) {
+          final p = placemarks.first;
+          // Build a readable name from the address components
+          final parts = <String>[
+            if (p.name != null && p.name!.isNotEmpty) p.name!,
+            if (p.street != null && p.street!.isNotEmpty && p.street != p.name) p.street!,
+            if (p.subLocality != null && p.subLocality!.isNotEmpty) p.subLocality!,
+          ];
+          if (parts.isNotEmpty) {
+            suggestedName = parts.take(2).join(', ');
+          }
+        }
+      } catch (_) {
+        // Geocoding failed — use default name
+      }
+
+      if (!context.mounted) return;
+
+      // Ask for name — pre-filled with auto-detected address
+      final name = await _askMasjidName(context, suggestedName);
       if (name == null || name.isEmpty) return;
 
       final masjid = SavedMasjid(
@@ -284,8 +310,11 @@ class MasjidScreen extends ConsumerWidget {
     }
   }
 
-  Future<String?> _askMasjidName(BuildContext context) async {
-    final controller = TextEditingController();
+  Future<String?> _askMasjidName(BuildContext context, [String? defaultName]) async {
+    final controller = TextEditingController(text: defaultName);
+    if (defaultName != null) {
+      controller.selection = TextSelection(baseOffset: 0, extentOffset: defaultName.length);
+    }
     return showDialog<String>(
       context: context,
       builder: (context) => AlertDialog(
@@ -293,9 +322,10 @@ class MasjidScreen extends ConsumerWidget {
         content: TextField(
           controller: controller,
           autofocus: true,
-          decoration: const InputDecoration(
+          decoration: InputDecoration(
             hintText: 'e.g. Masjid Al-Noor',
-            border: OutlineInputBorder(),
+            border: const OutlineInputBorder(),
+            helperText: defaultName != null ? 'Auto-detected from location' : null,
           ),
           textCapitalization: TextCapitalization.words,
           onSubmitted: (value) => Navigator.pop(context, value),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -160,6 +160,38 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  geocoding:
+    dependency: "direct main"
+    description:
+      name: geocoding
+      sha256: d580c801cba9386b4fac5047c4c785a4e19554f46be42f4f5e5b7deacd088a66
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
+  geocoding_android:
+    dependency: transitive
+    description:
+      name: geocoding_android
+      sha256: "1b13eca79b11c497c434678fed109c2be020b158cec7512c848c102bc7232603"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.3.1"
+  geocoding_ios:
+    dependency: transitive
+    description:
+      name: geocoding_ios
+      sha256: "18ab1c8369e2b0dcb3a8ccc907319334f35ee8cf4cfef4d9c8e23b13c65cb825"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
+  geocoding_platform_interface:
+    dependency: transitive
+    description:
+      name: geocoding_platform_interface
+      sha256: "8c2c8226e5c276594c2e18bfe88b19110ed770aeb7c1ab50ede570be8b92229b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.0"
   geolocator:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   go_router: ^14.8.1
   adhan: ^2.0.0+1
   intl: ^0.19.0
+  geocoding: ^3.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
Auto-detect address when saving masjid locations (pre-fills name dialog) + dark banner on home screen when masjid mode is active.

## Changes
- `screens/masjid_screen.dart`: Reverse geocoding via `geocoding` package to auto-suggest a name when saving current location. Falls back to "Masjid N". Name dialog pre-filled with "Auto-detected from location" helper.
- `screens/home_screen.dart`: Dark green banner appears when masjid mode active — shows mosque icon, status, remaining time, close button.
- `pubspec.yaml`: Added `geocoding: ^3.0.0`

## Validation
- [x] flutter analyze — 0 issues, flutter test — 22/22

## Known Limitations / Follow-ups
- Geofence-triggered masjid mode (from native GeofenceReceiver) doesn't update the Dart-side masjidModeProvider state yet — banner only shows for manually-activated masjid mode. Full native→Dart state sync is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
