### PR TITLE
fix: hide auto-silence chip when time-based is disabled

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -198,6 +198,7 @@ class HomeScreen extends ConsumerWidget {
             prayer: nextPrayer.$1,
             prayerTime: nextPrayer.$2,
             isSilenced: isSilenced,
+            timeBasedEnabled: timeBasedSilenceEnabled,
           ),
         const SizedBox(height: 24),
 

--- a/lib/widgets/next_prayer_banner.dart
+++ b/lib/widgets/next_prayer_banner.dart
@@ -7,12 +7,14 @@ class NextPrayerBanner extends StatefulWidget {
   final PrayerName prayer;
   final DateTime prayerTime;
   final bool isSilenced;
+  final bool timeBasedEnabled;
 
   const NextPrayerBanner({
     super.key,
     required this.prayer,
     required this.prayerTime,
     this.isSilenced = false,
+    this.timeBasedEnabled = false,
   });
 
   @override
@@ -134,35 +136,37 @@ class _NextPrayerBannerState extends State<NextPrayerBanner> {
               ),
             ],
           ),
-          const SizedBox(height: 14),
-          Container(
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-            decoration: BoxDecoration(
-              color: Colors.white.withValues(alpha: 0.15),
-              borderRadius: BorderRadius.circular(20),
-            ),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(
-                  widget.isSilenced ? Icons.volume_off : Icons.notifications_active,
-                  size: 14,
-                  color: Colors.white,
-                ),
-                const SizedBox(width: 6),
-                Text(
-                  widget.isSilenced
-                      ? 'Currently silenced'
-                      : 'Auto-silence in ${_formatDuration(_remaining)}',
-                  style: const TextStyle(
-                    fontSize: 12,
-                    fontWeight: FontWeight.w500,
+          if (widget.isSilenced || widget.timeBasedEnabled) ...[
+            const SizedBox(height: 14),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+              decoration: BoxDecoration(
+                color: Colors.white.withValues(alpha: 0.15),
+                borderRadius: BorderRadius.circular(20),
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    widget.isSilenced ? Icons.volume_off : Icons.notifications_active,
+                    size: 14,
                     color: Colors.white,
                   ),
-                ),
-              ],
+                  const SizedBox(width: 6),
+                  Text(
+                    widget.isSilenced
+                        ? 'Currently silenced'
+                        : 'Auto-silence in ${_formatDuration(_remaining)}',
+                    style: const TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w500,
+                      color: Colors.white,
+                    ),
+                  ),
+                ],
             ),
           ),
+          ],
         ],
       ),
     );


### PR DESCRIPTION
Hides the 'Auto-silence in Xm' chip on the next prayer banner when time-based silence is OFF.