### PR TITLE
fix: native geofence event logging with real timestamps

### DIFF
--- a/android/app/src/main/kotlin/com/respectful/respectful/GeofenceReceiver.kt
+++ b/android/app/src/main/kotlin/com/respectful/respectful/GeofenceReceiver.kt
@@ -86,6 +86,7 @@ class GeofenceReceiver : BroadcastReceiver() {
             .commit()
 
         Log.d(TAG, "Entered masjid(s): $masjidIds, active set: $activeMasjids")
+        NativeEventLog.log(context, "geofenceEnter", "Entered masjid — phone silenced")
     }
 
     private fun handleExitMasjid(
@@ -121,8 +122,10 @@ class GeofenceReceiver : BroadcastReceiver() {
                 )
                 volumeService.restoreState(savedState)
                 Log.d(TAG, "Exited all masjids — restored phone state")
+                NativeEventLog.log(context, "geofenceExit", "Left masjid — phone restored")
             } else {
                 Log.d(TAG, "Exited all masjids but prayer silence active — keeping silent")
+                NativeEventLog.log(context, "geofenceExit", "Left masjid — prayer still active")
             }
 
             // Clean up geo state

--- a/android/app/src/main/kotlin/com/respectful/respectful/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/respectful/respectful/MainActivity.kt
@@ -228,6 +228,10 @@ class MainActivity : FlutterActivity() {
                         result.success(false)
                     }
                 }
+                "readNativeEvents" -> {
+                    val events = NativeEventLog.readAndClear(this)
+                    result.success(events)
+                }
                 "isGeoSilenced" -> {
                     val prefs = getSharedPreferences(AlarmReceiver.PREFS_NAME, MODE_PRIVATE)
                     result.success(prefs.getBoolean("geo_silenced", false))

--- a/android/app/src/main/kotlin/com/respectful/respectful/NativeEventLog.kt
+++ b/android/app/src/main/kotlin/com/respectful/respectful/NativeEventLog.kt
@@ -1,0 +1,50 @@
+package com.respectful.respectful
+
+import android.content.Context
+import android.util.Log
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Simple native event logger that writes to SharedPreferences.
+ * Flutter reads these on app open and merges into the Dart event log.
+ * This ensures events from BroadcastReceivers (when Flutter is dead)
+ * are captured with correct timestamps.
+ */
+object NativeEventLog {
+    private const val TAG = "NativeEventLog"
+    private const val PREFS_NAME = "respectful_native_events"
+    private const val KEY = "events"
+    private const val MAX_EVENTS = 100
+
+    fun log(context: Context, type: String, message: String) {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val existing = prefs.getString(KEY, "[]") ?: "[]"
+
+        try {
+            val array = JSONArray(existing)
+            val event = JSONObject().apply {
+                put("type", type)
+                put("message", message)
+                put("timestamp", System.currentTimeMillis())
+            }
+            array.put(event)
+
+            // Cap at MAX_EVENTS — remove oldest
+            while (array.length() > MAX_EVENTS) {
+                array.remove(0)
+            }
+
+            prefs.edit().putString(KEY, array.toString()).commit()
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to log event: ${e.message}")
+        }
+    }
+
+    fun readAndClear(context: Context): String {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val events = prefs.getString(KEY, "[]") ?: "[]"
+        prefs.edit().putString(KEY, "[]").commit()
+        return events
+    }
+}

--- a/lib/providers/app_providers.dart
+++ b/lib/providers/app_providers.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/app_settings.dart';
 import '../models/prayer_day.dart';
@@ -288,27 +289,44 @@ final autoScheduleProvider = FutureProvider<void>((ref) async {
   );
 });
 
-// --- Geofence State (reads native geo_silenced flag) ---
-// Polls every 30 seconds. Logs transitions for the activity screen.
+/// Import native events (from GeofenceReceiver etc.) into Flutter's event log.
+/// Called on each geoSilenced poll — reads and clears native log.
+Future<void> _importNativeEvents(Ref ref) async {
+  try {
+    final controller = ref.read(volumeControllerProvider);
+    final eventLog = ref.read(eventLogServiceProvider);
+    final json = await controller.readNativeEvents();
 
-bool _lastGeoState = false;
+    if (json == '[]') return;
+
+    final List<dynamic> events = jsonDecode(json) as List;
+    for (final event in events) {
+      final type = event['type'] as String? ?? 'info';
+      final message = event['message'] as String? ?? '';
+
+      final eventType = type == 'geofenceEnter'
+          ? EventType.geofenceEnter
+          : type == 'geofenceExit'
+              ? EventType.geofenceExit
+              : EventType.info;
+
+      await eventLog.log(eventType, message);
+    }
+  } catch (_) {}
+}
+
+// --- Geofence State (reads native geo_silenced flag) ---
+// Polls every 30 seconds for UI state. Logging is done natively
+// by GeofenceReceiver — not here (avoids synthetic timestamps).
 
 final geoSilencedProvider = FutureProvider<bool>((ref) async {
   ref.watch(currentMinuteProvider); // refresh every 30s
   final controller = ref.read(volumeControllerProvider);
-  final current = await controller.isGeoSilenced();
 
-  if (current != _lastGeoState) {
-    final eventLog = ref.read(eventLogServiceProvider);
-    if (current) {
-      await eventLog.log(EventType.geofenceEnter, 'Entered masjid - phone silenced');
-    } else {
-      await eventLog.log(EventType.geofenceExit, 'Left masjid - phone restored');
-    }
-    _lastGeoState = current;
-  }
+  // Import native events into Flutter's event log on each poll
+  _importNativeEvents(ref);
 
-  return current;
+  return controller.isGeoSilenced();
 });
 final activeMasjidGeofencesProvider = FutureProvider<List<String>>((ref) async {
   ref.watch(currentMinuteProvider);

--- a/lib/services/volume_controller.dart
+++ b/lib/services/volume_controller.dart
@@ -120,6 +120,11 @@ class VolumeController {
     return await _channel.invokeMethod<bool>('forceRestoreNormal') ?? false;
   }
 
+  /// Read and clear native event log (events logged by GeofenceReceiver etc.)
+  Future<String> readNativeEvents() async {
+    return await _channel.invokeMethod<String>('readNativeEvents') ?? '[]';
+  }
+
   /// Check if phone is currently silenced by a geofence (native side).
   Future<bool> isGeoSilenced() async {
     return await _channel.invokeMethod<bool>('isGeoSilenced') ?? false;


### PR DESCRIPTION
Events now logged from native GeofenceReceiver, not synthetic Dart polling