### PR TITLE
fix: atomic swap geofence re-registration to prevent monitoring gaps

### DIFF
--- a/android/app/src/main/kotlin/com/respectful/respectful/GeofenceManager.kt
+++ b/android/app/src/main/kotlin/com/respectful/respectful/GeofenceManager.kt
@@ -130,6 +130,31 @@ object GeofenceManager {
             }
     }
 
+    /**
+     * Remove specific geofences by their request IDs.
+     * Used to clean up stale geofences after atomic swap re-registration.
+     */
+    fun removeGeofencesByIds(
+        context: Context,
+        ids: List<String>,
+        onComplete: (() -> Unit)? = null,
+    ) {
+        if (ids.isEmpty()) {
+            onComplete?.invoke()
+            return
+        }
+        val geofencingClient = LocationServices.getGeofencingClient(context)
+        geofencingClient.removeGeofences(ids)
+            .addOnSuccessListener {
+                Log.d(TAG, "Removed ${ids.size} stale geofences: $ids")
+                onComplete?.invoke()
+            }
+            .addOnFailureListener { e ->
+                Log.e(TAG, "Failed to remove stale geofences: ${e.message}")
+                onComplete?.invoke()
+            }
+    }
+
     private fun getGeofencePendingIntent(context: Context): PendingIntent {
         val intent = Intent(context, GeofenceReceiver::class.java)
         return PendingIntent.getBroadcast(

--- a/android/app/src/main/kotlin/com/respectful/respectful/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/respectful/respectful/MainActivity.kt
@@ -221,6 +221,15 @@ class MainActivity : FlutterActivity() {
                     )
                 }
 
+                "removeGeofencesByIds" -> {
+                    val ids = call.argument<List<String>>("ids") ?: emptyList()
+                    GeofenceManager.removeGeofencesByIds(
+                        this,
+                        ids,
+                        onComplete = { result.success(true) },
+                    )
+                }
+
                 "hasBackgroundLocationPermission" -> {
                     val granted = androidx.core.content.ContextCompat.checkSelfPermission(
                         this,

--- a/lib/providers/app_providers.dart
+++ b/lib/providers/app_providers.dart
@@ -735,6 +735,12 @@ final activeMasjidGeofencesProvider = FutureProvider<List<String>>((ref) async {
 
 // --- Geofence Auto-Registration ---
 // Watches saved masjids and auto-registers geofences when the list changes.
+// Uses atomic swap: register new geofences first (Play Services replaces
+// matching request IDs), then remove only stale IDs that are no longer needed.
+
+/// Tracks the set of masjid IDs from the last successful registration.
+/// Used to compute which IDs are stale and need removal after re-registration.
+Set<String> _lastRegisteredMasjidIds = {};
 
 final autoGeofenceProvider = FutureProvider<void>((ref) async {
   final masjids = ref.watch(savedMasjidsProvider);
@@ -745,15 +751,12 @@ final autoGeofenceProvider = FutureProvider<void>((ref) async {
       masjids.isEmpty ||
       !settings.geofenceSilenceEnabled) {
     await controller.removeGeofencesOnly();
+    _lastRegisteredMasjidIds = {};
     return;
   }
 
   final hasBgLocation = await controller.hasBackgroundLocationPermission();
   if (!hasBgLocation) return; // Can't register without background location
-
-  // Remove geofences only (not geo state) then re-add.
-  // Uses removeGeofencesOnly to preserve geo_silenced flag during re-registration.
-  await controller.removeGeofencesOnly();
 
   final masjidMaps = masjids
       .map(
@@ -766,9 +769,25 @@ final autoGeofenceProvider = FutureProvider<void>((ref) async {
       )
       .toList();
 
-  await controller.registerGeofences(masjidMaps);
+  final currentIds = masjids.map((m) => m.id).toSet();
+  final success = await controller.registerGeofences(masjidMaps);
 
   final eventLog = ref.read(eventLogServiceProvider);
+  if (!success) {
+    await eventLog.log(
+      EventType.error,
+      'Failed to register ${masjids.length} masjid geofences',
+    );
+    return;
+  }
+
+  // Remove only stale geofence IDs that are no longer in the saved list.
+  final staleIds = _lastRegisteredMasjidIds.difference(currentIds);
+  if (staleIds.isNotEmpty) {
+    await controller.removeGeofencesByIds(staleIds.toList());
+  }
+  _lastRegisteredMasjidIds = currentIds;
+
   await eventLog.log(
     EventType.info,
     'Registered ${masjids.length} masjid geofences',

--- a/lib/services/volume_controller.dart
+++ b/lib/services/volume_controller.dart
@@ -125,6 +125,13 @@ class VolumeController {
     await _channel.invokeMethod('removeGeofencesOnly');
   }
 
+  /// Remove specific geofences by ID. Used to clean up stale geofences
+  /// after atomic swap re-registration.
+  Future<void> removeGeofencesByIds(List<String> ids) async {
+    if (ids.isEmpty) return;
+    await _channel.invokeMethod('removeGeofencesByIds', {'ids': ids});
+  }
+
   /// Check if background location permission is granted.
   Future<bool> hasBackgroundLocationPermission() async {
     return await _channel.invokeMethod<bool>(

--- a/test/geo_exit_recovery_test.dart
+++ b/test/geo_exit_recovery_test.dart
@@ -65,6 +65,7 @@ class _FakeVolumeController extends VolumeController {
   int clearGeoSilenceCalls = 0;
   int removeGeofencesOnlyCalls = 0;
   int registerGeofencesCalls = 0;
+  List<String> removedGeofenceIds = [];
   int disableGeofenceSilenceCalls = 0;
   int clearManualOverridesCalls = 0;
   int clearGeoOverrideCalls = 0;
@@ -95,6 +96,11 @@ class _FakeVolumeController extends VolumeController {
   @override
   Future<void> removeGeofencesOnly() async {
     removeGeofencesOnlyCalls += 1;
+  }
+
+  @override
+  Future<void> removeGeofencesByIds(List<String> ids) async {
+    removedGeofenceIds.addAll(ids);
   }
 
   @override

--- a/test/geofence_presence_repair_test.dart
+++ b/test/geofence_presence_repair_test.dart
@@ -74,6 +74,7 @@ class _FakeEventLogService extends EventLogService {
 class _FakeVolumeController extends VolumeController {
   int removeGeofencesOnlyCalls = 0;
   int registerGeofencesCalls = 0;
+  List<String> removedGeofenceIds = [];
   final List<String?> appliedMasjidIds = [];
   final List<(String, int)> appliedPrayerWindows = [];
   bool applySilenceForGeoResult = true;
@@ -86,6 +87,11 @@ class _FakeVolumeController extends VolumeController {
   @override
   Future<void> removeGeofencesOnly() async {
     removeGeofencesOnlyCalls += 1;
+  }
+
+  @override
+  Future<void> removeGeofencesByIds(List<String> ids) async {
+    removedGeofenceIds.addAll(ids);
   }
 
   @override
@@ -225,7 +231,8 @@ void main() {
 
       expect(repaired, true);
       expect(controller.appliedMasjidIds, ['riyadh']);
-      expect(controller.removeGeofencesOnlyCalls, 1);
+      // Atomic swap: no removeGeofencesOnly before registration
+      expect(controller.removeGeofencesOnlyCalls, 0);
       expect(controller.registerGeofencesCalls, 1);
       expect(
         eventLog.messages,

--- a/test/masjid_interactions_test.dart
+++ b/test/masjid_interactions_test.dart
@@ -361,6 +361,9 @@ class _FakeVolumeController extends VolumeController {
   Future<void> syncGeoExitTracking() async {
     syncGeoExitTrackingCalls += 1;
   }
+
+  @override
+  Future<void> removeGeofencesByIds(List<String> ids) async {}
 }
 
 ProviderContainer _container({

--- a/test/silence_control_matrix_test.dart
+++ b/test/silence_control_matrix_test.dart
@@ -81,6 +81,7 @@ class _FakeVolumeController extends VolumeController {
   int disableGeofenceSilenceCalls = 0;
   int removeGeofencesOnlyCalls = 0;
   int registerGeofencesCalls = 0;
+  List<String> removedGeofenceIds = [];
   int clearManualOverridesCalls = 0;
   int clearPrayerOverrideCalls = 0;
   int clearGeoOverrideCalls = 0;
@@ -122,6 +123,11 @@ class _FakeVolumeController extends VolumeController {
   @override
   Future<void> removeGeofencesOnly() async {
     removeGeofencesOnlyCalls += 1;
+  }
+
+  @override
+  Future<void> removeGeofencesByIds(List<String> ids) async {
+    removedGeofenceIds.addAll(ids);
   }
 
   @override


### PR DESCRIPTION
## Summary
Replaces the remove-all-then-add-all geofence re-registration pattern with an atomic swap. Geofences are now registered first (Play Services replaces matching request IDs in place), then only stale IDs are removed. This prevents transient failures from leaving the device with zero active geofences.

## Changes
- `GeofenceManager.kt`: Added `removeGeofencesByIds()` — removes specific geofences by request ID using Play Services' `removeGeofences(List<String>)` overload
- `MainActivity.kt`: Added `removeGeofencesByIds` MethodChannel handler
- `volume_controller.dart`: Added `removeGeofencesByIds()` Flutter method
- `app_providers.dart`: Refactored `autoGeofenceProvider` — removed the pre-registration `removeGeofencesOnly()` call, added `registerGeofences()` result check with accurate error logging, computes stale IDs (set difference) and removes only those after successful registration
- Test mocks: Updated all 4 `_FakeVolumeController` classes with `removeGeofencesByIds` override

## Validation
- [x] `flutter analyze` passed (1 pre-existing warning)
- [x] `flutter test` — all 65 tests passed
- [x] No regressions introduced

## Known Limitations / Follow-ups
- `_lastRegisteredMasjidIds` is a module-level variable — it resets when the app process is killed. This is acceptable because Play Services persists geofences independently, and the first re-registration after restart will replace them anyway.
